### PR TITLE
Fix for existing incompatibility with ARM processors

### DIFF
--- a/src/hcd.cpp
+++ b/src/hcd.cpp
@@ -287,8 +287,8 @@ QImage HoughCircleDetector::edges(const QImage &source)
           
           /* accumulate */
           int gray = qGray(source.pixel(_x, _y));
-          new_x += Lx[i + 1][j + 1] * gray;
-          new_y += Ly[i + 1][j + 1] * gray;
+          new_x += static_cast<signed char>(Lx[i + 1][j + 1]) * gray;
+          new_y += static_cast<signed char>(Ly[i + 1][j + 1]) * gray;
         }
       }
       


### PR DESCRIPTION
Tried and failed to run this project on Raspberry Pi 3. 

Turned out problem was `char` signedness. Weirdly enough QByteArray is backed by `char`, which on ARM happens to be unsigned 
type. So basically `Ly[2][1] = -2;  Ly[2][2] = -1;` on ARM were implicitly converted to 255 and 254, which was breaking edge detection.